### PR TITLE
Minor automated testing tweaks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,13 @@ matrix:
     - php: '5.4'
     # aliased to a recent 5.5.x version
     - php: '5.5'
-      env: SNIFF=1
     # aliased to a recent 5.6.x version
     - php: '5.6'
-    # aliased to a recent 7.x version
+      env: SNIFF=1
+    # aliased to a recent 7.0.x version
     - php: '7.0'
+    # aliased to a recent 7.1.x version
+    - php: '7.1'
     # aliased to a recent hhvm version
     - php: 'hhvm'
 
@@ -34,18 +36,16 @@ matrix:
 
 before_script:
   - export PHPCS_DIR=/tmp/phpcs
-  - export WPCS_DIR=/tmp/wpcs
+  - export SNIFFS_DIR=/tmp/sniffs
   # Install CodeSniffer for WordPress Coding Standards checks.
   - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
   # Install WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
-  # Hop into CodeSniffer directory.
-  - if [[ "$SNIFF" == "1" ]]; then cd $PHPCS_DIR; fi
-  # Set install path for WordPress Coding Standards.
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b develop --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+  # Install PHP Compatibility sniffs.
+  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
+  # Set install path for PHPCS sniffs.
   # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $WPCS_DIR; fi
-  # Hop back into project dir.
-  - if [[ "$SNIFF" == "1" ]]; then cd $TRAVIS_BUILD_DIR; fi
+  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
   # After CodeSniffer install you should refresh your path.
   - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
 

--- a/class-debug-bar-constants.php
+++ b/class-debug-bar-constants.php
@@ -118,8 +118,7 @@ if ( ! class_exists( 'Debug_Bar_Constants' ) && class_exists( 'Debug_Bar_Panel' 
 			if ( isset( $class ) ) {
 				if ( is_string( $class ) && '' !== $class ) {
 					$classes .= ' ' . $class;
-				}
-				elseif ( ! empty( $class ) && is_array( $class ) ) {
+				} elseif ( ! empty( $class ) && is_array( $class ) ) {
 					$classes = $classes . ' ' . implode( ' ', $class );
 				}
 			}
@@ -130,8 +129,8 @@ if ( ! class_exists( 'Debug_Bar_Constants' ) && class_exists( 'Debug_Bar_Panel' 
 
 			if ( defined( 'Debug_Bar_Pretty_Output::VERSION' ) ) {
 				echo Debug_Bar_Pretty_Output::get_table( $array, $col1, $col2, $classes ); // WPCS: xss ok.
-			}
-			else {
+
+			} else {
 				// An old version of the pretty output class was loaded.
 				Debug_Bar_Pretty_Output::render_table( $array, $col1, $col2, $classes );
 			}
@@ -176,8 +175,8 @@ if ( ! class_exists( 'Debug_Bar_WP_Constants' ) && class_exists( 'Debug_Bar_Cons
 				echo '
 		<h2><span>', esc_html__( 'Constants within WP:', 'debug-bar-constants' ), '</span>', absint( count( $constants['user'] ) ), '</h2>';
 				$this->dbc_render_table( $constants['user'] );
-			}
-			else {
+
+			} else {
 				// Should never happen.
 				echo '<p>', esc_html__( 'No constants found... this is really weird...', 'debug-bar-constants' ), '</p>';
 			}
@@ -251,8 +250,7 @@ if ( ! class_exists( 'Debug_Bar_WP_Class_Constants' ) && class_exists( 'Debug_Ba
 					}
 					unset( $class, $set );
 				}
-			}
-			else {
+			} else {
 				// Should never happen.
 				echo '<p>', esc_html__( 'No classes nor class constants found... this is kinda strange...', 'debug-bar-constants' ), '</p>';
 			}
@@ -310,8 +308,8 @@ if ( ! class_exists( 'Debug_Bar_PHP_Constants' ) && class_exists( 'Debug_Bar_Con
 					}
 				}
 				unset( $category, $set, $title_attr );
-			}
-			else {
+
+			} else {
 				// Should never happen.
 				echo '<p>', esc_html__( 'No PHP constants found... this is really weird...', 'debug-bar-constants' ), '</p>';
 			}

--- a/debug-bar-constants.php
+++ b/debug-bar-constants.php
@@ -49,9 +49,9 @@ if ( ! function_exists( 'dbc_has_parent_plugin' ) ) {
 
 			// Add to recently active plugins list.
 			if ( ! is_network_admin() ) {
-				update_option( 'recently_activated', array( $file => time() ) + (array) get_option( 'recently_activated' ) );
+				update_option( 'recently_activated', ( array( $file => time() ) + (array) get_option( 'recently_activated' ) ) );
 			} else {
-				update_site_option( 'recently_activated', array( $file => time() ) + (array) get_site_option( 'recently_activated' ) );
+				update_site_option( 'recently_activated', ( array( $file => time() ) + (array) get_site_option( 'recently_activated' ) ) );
 			}
 
 			// Prevent trying again on page reload.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,19 +4,19 @@
 
 	<exclude-pattern>*/inc/debug-bar-pretty-output/*</exclude-pattern>
 
-	<rule ref="WordPress">
-		<!-- else on new line is perfectly fine -->
-		<exclude name="Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace" />
-	</rule>
+	<!-- ##### PHP cross-version compatibility ##### -->
+	<config name="testVersion" value="5.2-99.0"/>
+	<rule ref="PHPCompatibility"/>
+
+
+	<!-- ##### WordPress sniffs #####-->
+	<rule ref="WordPress" />
 
 	<!-- Add `PHP_Classes` to the whitelist for non-snakecase variable names. -->
 	<rule ref="WordPress.NamingConventions.ValidVariableName">
 	    <properties>
 	        <property name="customVariablesWhitelist" value="PHP_classes" type="array" />
 	    </properties>
-
-		<!-- TEMPORARY! Exclude a file until WPCS/PR #558 has been merged. -->
-		<exclude-pattern>class-debug-bar-constants.php</exclude-pattern>
 	</rule>
 
 


### PR DESCRIPTION
* Add PHP 7.1 to the travis test matrix as it will be released soon.
* Add sniffing for cross-PHP version compatibility to the PHPCS ruleset & add it to the travis script.
* Review excluded WP rules.
* Minor code style fix.

Temporarily change the WPCS branch to `develop` as it contains a fix for a certain sniff. This can be reverted back to `master` once WPCS 0.10.0 has been released.