### PR TITLE
Defer to just in time language loading for WP 4.6+.

### DIFF
--- a/class-debug-bar-constants.php
+++ b/class-debug-bar-constants.php
@@ -62,9 +62,24 @@ if ( ! class_exists( 'Debug_Bar_Constants' ) && class_exists( 'Debug_Bar_Panel' 
 		 *
 		 * Compatible with use of the plugin in the must-use plugins directory.
 		 *
+		 * {@internal No longer needed since WP 4.6, though the language loading in
+		 * WP 4.6 only looks at the `wp-content/languages/` directory and disregards
+		 * any translations which may be included with the plugin.
+		 * This is acceptable for plugins hosted on org, especially if the plugin
+		 * is new and never shipped with it's own translations, but not when the plugin
+		 * is hosted elsewhere.
+		 * Can be removed if/when the minimum required version for this plugin is ever
+		 * upped to 4.6. The `languages` directory can be removed in that case too.
+		 * See: {@link https://core.trac.wordpress.org/ticket/34213} and
+		 * {@link https://core.trac.wordpress.org/ticket/34114} }}
+		 *
 		 * @param string $domain Text domain to load.
 		 */
 		protected function load_textdomain( $domain ) {
+			if ( function_exists( '_load_textdomain_just_in_time' ) ) {
+				return;
+			}
+
 			if ( is_textdomain_loaded( $domain ) || self::$textdomain_loaded ) {
 				return;
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,9 @@ Have you read what it says in the beautifully red bar at the top of your plugins
 
 == Changelog ==
 
+= Trunk (xxxx-xx-xx) =
+* Defer to just in time loading of translations for WP > 4.5.
+
 = 1.6.1 (2016-04-15) =
 * Get the leaner loading of text domains right (at last).
 


### PR DESCRIPTION
When WP 4.6 or higher is used, the `load_plugin_textdomain()` function call is no longer necessary.

As this plugin, however, is also compatible with older WP versions and could still be used to debug older installs, don't remove the language loading completely, nor the languages subdirectory (yet).