### PR TITLE
Refactor: split the base class into a controller and a panel base class

### DIFF
--- a/class-debug-bar-constants-panel.php
+++ b/class-debug-bar-constants-panel.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Debug Bar Constants Panel - Base class for a Debug Bar Constants Debug Bar Panels.
+ *
+ * @package     WordPress\Plugins\Debug Bar Constants
+ * @author      Juliette Reinders Folmer <wpplugins_nospam@adviesenzo.nl>
+ * @link        https://github.com/jrfnl/Debug-Bar-Constants
+ *
+ * @copyright   2013-2017 Juliette Reinders Folmer
+ * @license     http://creativecommons.org/licenses/GPL/2.0/ GNU General Public License, version 2 or higher
+ */
+
+// Avoid direct calls to this file.
+if ( ! function_exists( 'add_action' ) ) {
+	header( 'Status: 403 Forbidden' );
+	header( 'HTTP/1.1 403 Forbidden' );
+	exit();
+}
+
+
+if ( ! class_exists( 'Debug_Bar_Constants_Panel' ) && class_exists( 'Debug_Bar_Panel' ) ) {
+
+	/**
+	 * Base class.
+	 */
+	abstract class Debug_Bar_Constants_Panel extends Debug_Bar_Panel {
+
+		/**
+		 * Should the tab be visible ?
+		 * You can set conditions here so something will for instance only show on the front- or the
+		 * back-end.
+		 */
+		public function prerender() {
+			$this->set_visible( true );
+		}
+
+
+		/**
+		 * Helper method to render the output in a table.
+		 *
+		 * @param array             $array Array to be shown in the table.
+		 * @param string|null       $col1  Label for the first table column.
+		 * @param string|null       $col2  Label for the second table column.
+		 * @param string|array|null $class One or more CSS classes to add to the table.
+		 */
+		public function dbc_render_table( $array, $col1 = null, $col2 = null, $class = null ) {
+
+			$classes = Debug_Bar_Constants::DBC_NAME;
+			if ( isset( $class ) ) {
+				if ( is_string( $class ) && '' !== $class ) {
+					$classes .= ' ' . $class;
+				} elseif ( ! empty( $class ) && is_array( $class ) ) {
+					$classes = $classes . ' ' . implode( ' ', $class );
+				}
+			}
+			$col1 = ( isset( $col1 ) ? $col1 : __( 'Name', 'debug-bar-constants' ) );
+			$col2 = ( isset( $col2 ) ? $col2 : __( 'Value', 'debug-bar-constants' ) );
+
+			uksort( $array, 'strnatcasecmp' );
+
+			if ( defined( 'Debug_Bar_Pretty_Output::VERSION' ) ) {
+				echo Debug_Bar_Pretty_Output::get_table( $array, $col1, $col2, $classes ); // WPCS: xss ok.
+
+			} else {
+				// An old version of the pretty output class was loaded.
+				Debug_Bar_Pretty_Output::render_table( $array, $col1, $col2, $classes );
+			}
+		}
+	} // End of class Debug_Bar_Constants_Panel.
+
+} // End of if class_exists wrapper.

--- a/class-debug-bar-php-constants.php
+++ b/class-debug-bar-php-constants.php
@@ -18,12 +18,12 @@ if ( ! function_exists( 'add_action' ) ) {
 }
 
 
-if ( ! class_exists( 'Debug_Bar_PHP_Constants' ) && class_exists( 'Debug_Bar_Constants' ) ) {
+if ( ! class_exists( 'Debug_Bar_PHP_Constants' ) && class_exists( 'Debug_Bar_Constants_Panel' ) ) {
 
 	/**
 	 * Debug Bar PHP Constants.
 	 */
-	class Debug_Bar_PHP_Constants extends Debug_Bar_Constants {
+	class Debug_Bar_PHP_Constants extends Debug_Bar_Constants_Panel {
 
 
 		/**

--- a/class-debug-bar-wp-class-constants.php
+++ b/class-debug-bar-wp-class-constants.php
@@ -18,12 +18,12 @@ if ( ! function_exists( 'add_action' ) ) {
 }
 
 
-if ( ! class_exists( 'Debug_Bar_WP_Class_Constants' ) && class_exists( 'Debug_Bar_Constants' ) ) {
+if ( ! class_exists( 'Debug_Bar_WP_Class_Constants' ) && class_exists( 'Debug_Bar_Constants_Panel' ) ) {
 
 	/**
 	 * Debug Bar WP Class Constants.
 	 */
-	class Debug_Bar_WP_Class_Constants extends Debug_Bar_Constants {
+	class Debug_Bar_WP_Class_Constants extends Debug_Bar_Constants_Panel {
 
 
 		/**

--- a/class-debug-bar-wp-constants.php
+++ b/class-debug-bar-wp-constants.php
@@ -18,12 +18,12 @@ if ( ! function_exists( 'add_action' ) ) {
 }
 
 
-if ( ! class_exists( 'Debug_Bar_WP_Constants' ) && class_exists( 'Debug_Bar_Constants' ) ) {
+if ( ! class_exists( 'Debug_Bar_WP_Constants' ) && class_exists( 'Debug_Bar_Constants_Panel' ) ) {
 
 	/**
 	 * Debug Bar WP Constants.
 	 */
-	class Debug_Bar_WP_Constants extends Debug_Bar_Constants {
+	class Debug_Bar_WP_Constants extends Debug_Bar_Constants_Panel {
 
 
 		/**

--- a/debug-bar-constants.php
+++ b/debug-bar-constants.php
@@ -67,27 +67,20 @@ if ( ! function_exists( 'dbc_has_parent_plugin' ) ) {
 }
 
 
+if ( ! function_exists( 'debug_bar_constants_init' ) ) {
 
-if ( ! function_exists( 'debug_bar_constants_panels' ) ) {
-	// Low priority, no need for it to be high up in the list.
-	add_filter( 'debug_bar_panels', 'debug_bar_constants_panels', 12 );
+	// wp_installing() function was introduced in WP 4.4.
+	if ( ( function_exists( 'wp_installing' ) && wp_installing() === false ) || ( ! function_exists( 'wp_installing' ) && ( ! defined( 'WP_INSTALLING' ) || WP_INSTALLING === false ) ) ) {
+		add_action( 'plugins_loaded', 'debug_bar_constants_init' );
+	}
 
 	/**
-	 * Add the Debug Bar Constant panels to the Debug Bar.
+	 * Initialize the class.
 	 *
-	 * @param array $panels Existing debug bar panels.
-	 *
-	 * @return array
+	 * @return void
 	 */
-	function debug_bar_constants_panels( $panels ) {
-		require_once 'class-debug-bar-constants.php';
-		require_once 'class-debug-bar-php-constants.php';
-		require_once 'class-debug-bar-wp-constants.php';
-		require_once 'class-debug-bar-wp-class-constants.php';
-
-		$panels[] = new Debug_Bar_WP_Constants();
-		$panels[] = new Debug_Bar_WP_Class_Constants();
-		$panels[] = new Debug_Bar_PHP_Constants();
-		return $panels;
+	function debug_bar_constants_init() {
+		include_once plugin_dir_path( __FILE__ ) . 'class-debug-bar-constants.php';
+		$debug_bar_constants = new Debug_Bar_Constants();
 	}
 }


### PR DESCRIPTION
This way the text domain and script loading is always only done once.

Also makes the panel base class `abstract` for compatibility with DB 0.10.0.