### PR TITLE
Compatibility with the Debug Bar 0.10.0 version

### DIFF
--- a/class-debug-bar-php-constants.php
+++ b/class-debug-bar-php-constants.php
@@ -30,7 +30,6 @@ if ( ! class_exists( 'Debug_Bar_PHP_Constants' ) && class_exists( 'Debug_Bar_Con
 		 * Constructor.
 		 */
 		public function init() {
-			parent::init();
 			$this->title( __( 'PHP Constants', 'debug-bar-constants' ) );
 		}
 

--- a/class-debug-bar-wp-class-constants.php
+++ b/class-debug-bar-wp-class-constants.php
@@ -30,7 +30,6 @@ if ( ! class_exists( 'Debug_Bar_WP_Class_Constants' ) && class_exists( 'Debug_Ba
 		 * Constructor.
 		 */
 		public function init() {
-			parent::init();
 			$this->title( __( 'WP Class Constants', 'debug-bar-constants' ) );
 		}
 

--- a/class-debug-bar-wp-constants.php
+++ b/class-debug-bar-wp-constants.php
@@ -30,7 +30,6 @@ if ( ! class_exists( 'Debug_Bar_WP_Constants' ) && class_exists( 'Debug_Bar_Cons
 		 * Constructor.
 		 */
 		public function init() {
-			parent::init();
 			$this->title( __( 'WP Constants', 'debug-bar-constants' ) );
 		}
 


### PR DESCRIPTION
The parent `init()` method was an empty method and has now been turned into an `abstract` method, so calling it will cause a fatal error (and is useless anyway).